### PR TITLE
Incoming Http request metrics

### DIFF
--- a/datadog/request-metrics.json
+++ b/datadog/request-metrics.json
@@ -67,7 +67,7 @@
           {
             "id": 5890661141790956,
             "definition": {
-              "title": "Throughput Rate",
+              "title": "Throughput: Requests Per Second",
               "title_size": "16",
               "title_align": "left",
               "show_legend": true,
@@ -79,6 +79,7 @@
                 "value",
                 "sum"
               ],
+              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -501,6 +502,82 @@
               "width": 6,
               "height": 1
             }
+          },
+          {
+            "id": 2996807578664040,
+            "definition": {
+              "title": "Router Internal Latency",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": true,
+              "legend_layout": "auto",
+              "legend_columns": [
+                "avg",
+                "min",
+                "max",
+                "value",
+                "sum"
+              ],
+              "time": {},
+              "type": "timeseries",
+              "requests": [
+                {
+                  "response_format": "timeseries",
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "p95:http.server.request.duration{$service}"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "query2",
+                      "query": "p95:http.client.request.duration{$service , subgraph.name:*}"
+                    }
+                  ],
+                  "formulas": [
+                    {
+                      "alias": "P95 Router Overhead",
+                      "formula": "query1 - query2"
+                    }
+                  ],
+                  "style": {
+                    "palette": "dog_classic",
+                    "order_by": "values",
+                    "line_type": "solid",
+                    "line_width": "normal"
+                  },
+                  "display_type": "line"
+                }
+              ]
+            },
+            "layout": {
+              "x": 0,
+              "y": 7,
+              "width": 6,
+              "height": 3
+            }
+          },
+          {
+            "id": 758034316141236,
+            "definition": {
+              "type": "note",
+              "content": "Ideally this chart shows how much time (P95) is spent inside the Router vs waiting on subgraphs.\n\n**Where Time is Spent** \n\n-   **Higher values** suggest internal Router work: merging, `@requires`, retries, etc.\n-   **Lower values** (close to 0) indicate subgraphs dominate latency and the router is highly performant.\n\n Helps diagnose whether optimizations are needed in the Router or subgraphs.\n    \n### Caveats & Considerations\n\n-   **Not a precise breakdown**\\\n    The chart gives an approximation—`server - client` infers Router time, but doesn’t capture exact Router internals.\n-   **Parallelism in subgraph calls**\\\n    The Router can send subgraph requests in parallel. So `http.client.request.duration` might not equal the sum of all subgraph durations—it reflects _wall time_, not total subgraph work.\n-   **Retries and fallback logic**\\\n    Router retry behavior (e.g., on 5xxs or network failures) can inflate Router time but not necessarily show up in client-side metrics as multiple attempts.",
+              "background_color": "yellow",
+              "font_size": "14",
+              "text_align": "left",
+              "vertical_align": "top",
+              "show_tick": true,
+              "tick_pos": "50%",
+              "tick_edge": "top",
+              "has_padding": true
+            },
+            "layout": {
+              "x": 0,
+              "y": 10,
+              "width": 6,
+              "height": 1
+            }
           }
         ]
       },
@@ -508,7 +585,7 @@
         "x": 0,
         "y": 0,
         "width": 12,
-        "height": 8,
+        "height": 12,
         "is_column_break": true
       }
     }


### PR DESCRIPTION
[Dashboard Section in Datadog](https://app.datadoghq.com/dashboard/rqe-it2-pcw?fromUser=false&refresh_mode=sliding&tpl_var_service%5B0%5D=observability-workshop-router&from_ts=1748985713229&to_ts=1749072113229&live=true)

[RR-65](https://apollographql.atlassian.net/browse/RR-65)

[http.server.response.body.size](https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpserverresponsebodysize) was listed in the apm dashboard template design doc as a required metric, but unfortunately it could not be found in datadog even though it is configured in the router.yml of the production routers and my observability-workshop demo router. I have a thread in [#inbox-router](https://apollograph.slack.com/archives/C02UX05LF4K/p1748881350890919) to figure out what is going on. For now i am leaving it out of the dashboard so that i can move on. 


You will notice that I only have a single filtered configured for the service name. env and version were not available filters. I've created [RR-96](https://apollographql.atlassian.net/browse/RR-96) as a follow up to address this problem and see if its possible to add those data points to the metrics produced by the router. 





[RR-65]: https://apollographql.atlassian.net/browse/RR-65?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RR-96]: https://apollographql.atlassian.net/browse/RR-96?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ