### PR TITLE
Subgraph Request Metrics Dashboard Section

### DIFF
--- a/datadog/subgraph-request-metrics.json
+++ b/datadog/subgraph-request-metrics.json
@@ -1,0 +1,703 @@
+{
+  "title": "RR-66 outgoing http request metrics",
+  "description": "[[suggested_dashboards]]",
+  "widgets": [
+    {
+      "id": 8946993247458357,
+      "definition": {
+        "title": "Request Traffic & Health: Router -> Subgraph",
+        "background_color": "vivid_blue",
+        "show_title": true,
+        "type": "group",
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "id": 1224218507683046,
+            "definition": {
+              "title": "Http Requests by Status Code",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": false,
+              "legend_layout": "vertical",
+              "legend_columns": [
+                "avg",
+                "min",
+                "max",
+                "value",
+                "sum"
+              ],
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [
+                    {
+                      "formula": "query1"
+                    }
+                  ],
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "count:http.client.request.duration{$service} by {subgraph.name,http.response.status_code}.as_count()"
+                    }
+                  ],
+                  "response_format": "timeseries",
+                  "style": {
+                    "palette": "semantic",
+                    "order_by": "values",
+                    "line_type": "solid",
+                    "line_width": "normal"
+                  },
+                  "display_type": "bars"
+                }
+              ]
+            },
+            "layout": {
+              "x": 0,
+              "y": 0,
+              "width": 6,
+              "height": 4
+            }
+          },
+          {
+            "id": 8436708637768666,
+            "definition": {
+              "title": "Throughput (Requests per Second)",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": false,
+              "legend_layout": "auto",
+              "legend_columns": [
+                "avg",
+                "min",
+                "max",
+                "value",
+                "sum"
+              ],
+              "type": "timeseries",
+              "requests": [
+                {
+                  "response_format": "timeseries",
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "count:http.client.request.duration{$service} by {subgraph.name}.as_count()"
+                    }
+                  ],
+                  "formulas": [
+                    {
+                      "alias": "Requests per second",
+                      "formula": "throughput(query1)"
+                    }
+                  ],
+                  "style": {
+                    "palette": "semantic",
+                    "order_by": "values",
+                    "line_type": "solid",
+                    "line_width": "normal"
+                  },
+                  "display_type": "line"
+                }
+              ]
+            },
+            "layout": {
+              "x": 6,
+              "y": 0,
+              "width": 6,
+              "height": 4
+            }
+          },
+          {
+            "id": 1604866605637428,
+            "definition": {
+              "type": "note",
+              "content": "This chart shows the volume of outgoing HTTP requests from the Router to subgraphs, broken down by HTTP status code and subgraph.\n\n**Why it matters:**\n\n-   Tracks overall subgraph traffic.\n\nWhat to look for:\n\n-   High volume of `2xx` is normal and healthy.",
+              "background_color": "yellow",
+              "font_size": "14",
+              "text_align": "left",
+              "vertical_align": "top",
+              "show_tick": true,
+              "tick_pos": "50%",
+              "tick_edge": "top",
+              "has_padding": true
+            },
+            "layout": {
+              "x": 0,
+              "y": 4,
+              "width": 6,
+              "height": 1
+            }
+          },
+          {
+            "id": 8148807184808558,
+            "definition": {
+              "type": "note",
+              "content": "This chart shows how many requests per second (RPS) each subgraph is handling. It's useful for understanding traffic distribution across your federated architecture and identifying which subgraphs are the busiest.\n\n**What to Look For:**\n\n-   **Consistently high RPS** on a subgraph may indicate:\n\n    -   It supports popular or frequently queried fields.\n    -   It could become a performance bottleneck if not properly scaled or optimized.\n\n-   **Sudden spikes** can signal usage surges or potential issues downstream (e.g., retry storms).\n\n-   **Low RPS subgraphs** might be underutilized or intentionally lightweight.\n\n**Actionable Insights:**\n\n-   Ensure high-throughput subgraphs are well-instrumented and autoscaled where possible.\n-   Investigate traffic spikes for correlation with client activity or backend issues.\n-   Cross-reference with latency charts to catch early signs of degradation under load.\n\n**Caveats:**\n\n-   This reflects traffic from the Router to each subgraph, not necessarily user-facing load.\n-   Subgraphs handling many small, fast requests may show high RPS but minimal latency or load — context is key.",
+              "background_color": "yellow",
+              "font_size": "14",
+              "text_align": "left",
+              "vertical_align": "center",
+              "show_tick": true,
+              "tick_pos": "50%",
+              "tick_edge": "top",
+              "has_padding": true
+            },
+            "layout": {
+              "x": 6,
+              "y": 4,
+              "width": 6,
+              "height": 1
+            }
+          },
+          {
+            "id": 3375905945773031,
+            "definition": {
+              "title": "Non-2xx Responses",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": true,
+              "legend_layout": "vertical",
+              "legend_columns": [
+                "avg",
+                "min",
+                "max",
+                "value",
+                "sum"
+              ],
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [
+                    {
+                      "alias": "Sum",
+                      "formula": "query1"
+                    }
+                  ],
+                  "queries": [
+                    {
+                      "query": "count:http.client.request.duration{subgraph.name:*,!http.response.status_code:2*,$service} by {subgraph.name,http.response.status_code}.as_count()",
+                      "data_source": "metrics",
+                      "name": "query1"
+                    }
+                  ],
+                  "response_format": "timeseries",
+                  "style": {
+                    "palette": "semantic",
+                    "line_type": "dotted",
+                    "line_width": "normal"
+                  },
+                  "display_type": "bars"
+                }
+              ],
+              "yaxis": {
+                "include_zero": false
+              },
+              "markers": []
+            },
+            "layout": {
+              "x": 0,
+              "y": 5,
+              "width": 8,
+              "height": 4
+            }
+          },
+          {
+            "id": 8928058460124150,
+            "definition": {
+              "type": "note",
+              "content": "**Recommended SLOs & Alerts:**\n\n-   Alert on sustained increases in 5xx responses from any subgraph.\n-   Reliability SLO: ≥99.9% of Router→subgraph requests should be 2xx and without error.",
+              "background_color": "white",
+              "font_size": "14",
+              "text_align": "left",
+              "vertical_align": "top",
+              "show_tick": false,
+              "tick_pos": "50%",
+              "tick_edge": "left",
+              "has_padding": true
+            },
+            "layout": {
+              "x": 8,
+              "y": 5,
+              "width": 4,
+              "height": 2
+            }
+          },
+          {
+            "id": 2347349834910780,
+            "definition": {
+              "type": "note",
+              "content": "### Throughput Categories\n\n**Low Throughput:** Fewer than **10 requests per minute (RPM)** (~0.17 RPS)\n-  Metrics like P95 latency and error rates may be unreliable. You’re likely looking at isolated client activity or background tasks due to the api not being warm.\n-  Monitor with logs, traces, or uptime checks, not SLO-based alerts\n\n**Moderate Throughput:** Between **10 and 100 RPM** (~0.17 to ~1.7 RPS)\n-   Enough volume to detect trends, but not enough to be confident in moment-to-moment alerting.\n-  Use conservative thresholds on any alerts and look for trends over longer windows of time\n\n**High _(enough)_ Throughput:** Greater than **100 RPM** (>1.7 RPS)\n-  Generally enough for real-time alerting and solid SLO enforcement",
+              "background_color": "white",
+              "font_size": "14",
+              "text_align": "left",
+              "vertical_align": "top",
+              "show_tick": false,
+              "tick_pos": "50%",
+              "tick_edge": "left",
+              "has_padding": true
+            },
+            "layout": {
+              "x": 8,
+              "y": 7,
+              "width": 4,
+              "height": 3
+            }
+          },
+          {
+            "id": 6943674061818587,
+            "definition": {
+              "type": "note",
+              "content": "This chart focuses specifically on non-successful(non-2xx) responses from subgraphs — grouped by subgraph and status code.\n\n**Why it matters:**\n\n-   These are the requests that failed, either due to config errors (4xx) or server-side issues (5xx).\n-   The Router isn’t failing — it’s forwarding a query that the subgraph can't fulfill.\n\n**Common causes of 4xx:**\n\n-   Schema mismatch between subgraph and Supergraph (e.g., schema drift)\n-   Missing auth headers or invalid inputs\n\n**Common causes of 5xx:**\n\n-   Crashes, timeouts, or errors in a subgraphs logic\n\n**How this impacts Router performance:**\n\n-   Frequent 5xxs inflate latency as the Router retries or collects error details.\n-   Repeated 4xxs may be harmless, but still consume Router resources and can signal client or schema issues.\n\n\n**Pro tip:**\\\nIf a subgraph frequently appears here, coordinate with its owning team to investigate error logs or validate schema compatibility.\n\n**Caveats**\n- You might see `N/A` as a status code. This means that a request was made but a response was not received. ",
+              "background_color": "yellow",
+              "font_size": "14",
+              "text_align": "left",
+              "vertical_align": "top",
+              "show_tick": true,
+              "tick_pos": "50%",
+              "tick_edge": "top",
+              "has_padding": true
+            },
+            "layout": {
+              "x": 0,
+              "y": 9,
+              "width": 8,
+              "height": 1
+            }
+          }
+        ]
+      },
+      "layout": {
+        "x": 0,
+        "y": 0,
+        "width": 12,
+        "height": 11
+      }
+    },
+    {
+      "id": 3840969086320674,
+      "definition": {
+        "title": " Request Characteristics: Router -> Subgraph",
+        "background_color": "vivid_blue",
+        "show_title": true,
+        "type": "group",
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "id": 5703355397898961,
+            "definition": {
+              "title": "Response Body Size",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": true,
+              "legend_layout": "auto",
+              "legend_columns": [
+                "avg",
+                "min",
+                "max",
+                "value",
+                "sum"
+              ],
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [
+                    {
+                      "alias": "Sum",
+                      "formula": "query4",
+                      "number_format": {
+                        "unit": {
+                          "type": "canonical_unit",
+                          "unit_name": "byte_in_decimal_bytes_family"
+                        }
+                      }
+                    }
+                  ],
+                  "queries": [
+                    {
+                      "name": "query4",
+                      "data_source": "metrics",
+                      "query": "avg:http.client.response.body.size{$service} by {subgraph.name}.as_count()"
+                    }
+                  ],
+                  "response_format": "timeseries",
+                  "style": {
+                    "palette": "semantic",
+                    "line_type": "solid",
+                    "line_width": "normal"
+                  },
+                  "display_type": "line"
+                }
+              ],
+              "markers": []
+            },
+            "layout": {
+              "x": 0,
+              "y": 0,
+              "width": 7,
+              "height": 4
+            }
+          },
+          {
+            "id": 5212470527428142,
+            "definition": {
+              "type": "note",
+              "content": "This chart tracks the total volume of response data returned by each subgraph over time. It helps identify subgraphs that are consistently returning large payloads, which can impact overall performance and client-side load times.\n\n**What to Look For:**\n\n-   **Spikes or sustained high values** from a subgraph may indicate:\n\n    -   Overfetching: unnecessary fields being resolved and returned.\n    -   Inefficient schema design: returning deeply nested or verbose structures.\n    -   Missing pagination or filtering on list-type fields.\n\n-   **Flat, low-volume subgraphs** could either be healthy or underutilized — context matters.\n\n**Actionable Insights:**\n\n-   Audit GraphQL queries hitting high-volume subgraphs.\n-   Consider schema redesigns to reduce payload size (e.g., use fragments, `@defer`, or pagination).\n-   If the size is expected (e.g., media, large objects), ensure proper compression is in place.\n\n**Caveats:**\n\n-   Values are based on the `Content-Length` header and may not reflect actual decompressed payload size.\n-   This metric tracks data size **returned by subgraphs**, not what is ultimately sent to the client by the router.",
+              "background_color": "yellow",
+              "font_size": "14",
+              "text_align": "left",
+              "vertical_align": "top",
+              "show_tick": true,
+              "tick_pos": "50%",
+              "tick_edge": "top",
+              "has_padding": true
+            },
+            "layout": {
+              "x": 0,
+              "y": 4,
+              "width": 7,
+              "height": 1
+            }
+          }
+        ]
+      },
+      "layout": {
+        "x": 0,
+        "y": 11,
+        "width": 12,
+        "height": 6
+      }
+    },
+    {
+      "id": 2547398354023131,
+      "definition": {
+        "title": "Request Performance & Latency: Router -> Subgraph",
+        "background_color": "vivid_blue",
+        "show_title": true,
+        "type": "group",
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "id": 7559571845461086,
+            "definition": {
+              "title": "P95 Latency",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": false,
+              "legend_layout": "auto",
+              "legend_columns": [
+                "avg",
+                "min",
+                "max",
+                "value",
+                "sum"
+              ],
+              "type": "timeseries",
+              "requests": [
+                {
+                  "response_format": "timeseries",
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "p95:http.client.request.duration{$service} by {subgraph.name}"
+                    }
+                  ],
+                  "formulas": [
+                    {
+                      "alias": "P95 Latency (Seconds)",
+                      "formula": "query1"
+                    }
+                  ],
+                  "style": {
+                    "palette": "semantic",
+                    "order_by": "values",
+                    "line_type": "solid",
+                    "line_width": "normal"
+                  },
+                  "display_type": "line"
+                }
+              ]
+            },
+            "layout": {
+              "x": 0,
+              "y": 0,
+              "width": 6,
+              "height": 4
+            }
+          },
+          {
+            "id": 4614292295630845,
+            "definition": {
+              "title": "Subgraph Performance Profile",
+              "title_size": "16",
+              "title_align": "left",
+              "time": {
+                "type": "live",
+                "unit": "week",
+                "value": 1
+              },
+              "type": "scatterplot",
+              "requests": {
+                "table": {
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "count:http.client.request.duration{$service} by {subgraph.name}.as_count()",
+                      "aggregator": "sum"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "query2",
+                      "query": "p95:http.client.request.duration{$service} by {subgraph.name}",
+                      "aggregator": "percentile"
+                    }
+                  ],
+                  "formulas": [
+                    {
+                      "alias": "Requests",
+                      "dimension": "x",
+                      "formula": "throughput(query1)"
+                    },
+                    {
+                      "dimension": "y",
+                      "alias": "P95 Latency (Seconds)",
+                      "formula": "query2"
+                    }
+                  ]
+                }
+              },
+              "xaxis": {
+                "scale": "linear",
+                "include_zero": true,
+                "min": "auto",
+                "max": "auto"
+              },
+              "yaxis": {
+                "scale": "linear",
+                "include_zero": true,
+                "min": "auto",
+                "max": "auto"
+              },
+              "color_by_groups": [
+                "subgraph.name"
+              ]
+            },
+            "layout": {
+              "x": 6,
+              "y": 0,
+              "width": 6,
+              "height": 4
+            }
+          },
+          {
+            "id": 422220421274293,
+            "definition": {
+              "type": "note",
+              "content": "This chart tracks the 95th percentile (P95) request duration from the Router to each subgraph.\n\n### Why It Matters\n\n-   P95 is more **resilient to outliers** than max but still reveals tail latency problems that affect real users.\n\n### What to Look For\n\n-   📈 **Rising P95** values can indicate:\n\n    -   Backend slowness\n    -   Schema changes causing more complex queries\n    -   Increased load on subgraphs\n\n-   📉 **Flat or low P95** suggests stable performance under current conditions.\n\n-   🔁 **Correlate with throughput** — rising latency during peak traffic may mean you’re under-provisioned.\n\n\n### Actionable Insights\n\n-   Investigate consistently high-latency subgraphs — even if they aren’t crashing, they may be degrading user experience.\n-   Compare with response body size and throughput to find potential root causes (e.g., payload bloat or traffic spikes).\n-   Check if retry or @requires patterns are contributing.\n\n\n### Caveats\n\n-   P95 latency is unreliable for low-throughput subgraphs because small sample sizes let outliers disproportionately skew the metric, making it hard to distinguish real issues from statistical noise.\n-   P95 doesn’t reveal all latency issues — check the distribution chart for outliers and long tails.\n",
+              "background_color": "yellow",
+              "font_size": "14",
+              "text_align": "left",
+              "vertical_align": "top",
+              "show_tick": true,
+              "tick_pos": "50%",
+              "tick_edge": "top",
+              "has_padding": true
+            },
+            "layout": {
+              "x": 0,
+              "y": 4,
+              "width": 6,
+              "height": 1
+            }
+          },
+          {
+            "id": 6615090037432379,
+            "definition": {
+              "type": "note",
+              "content": "This chart aids in assessing the performance of individual subgraphs by correlating their request handling with their response times in order to identify hotspots and bottlenecks. \n\n**What to Look For:**\n- **Top right** = _hotspot / bottleneck_\n- **Bottom left** = _healthy_\n\nGood\n-   **Bottom-Right Quadrant (High RPS & Low Latency):** Ideal scenario indicating efficient subgraphs.\n-   **Bottom-Left Quadrant (Low RPS & Low Latency):** Efficient but underutilized.\n\nWarning\n-   **Top-Left Quadrant (Low RPS & High Latency):** Underutilized and slow; potential future bottlenecks or issues if traffic increases. \n\nBad\n-   **Top-Right Quadrant (High RPS & High Latency ):** Subgraphs handling many requests with slower responses; may need optimization.\n\n**Actionable Insights:**\n\n-   **Optimize High-Latency Subgraphs:** Perform schema optimizations or improve the performance of subgraphs. Starting with ones in the top right. \n-   **Annotate Known Outliers:** Use a note widget or annotations to explain any known anomalies:\n    -  “This subgraph is intentionally slow due to external API call.”\n    -  “This one was recently scaled — latency is expected to improve.”\n\n**Caveats:**\n\n- **Axes Auto-Scale:** This scatterplot dynamically adjusts its axes based on the current data. As a result, a subgraph may appear in the top-right corner simply due to a narrow overall range — not necessarily because it has poor performance. Always interpret positions relative to other subgraphs, and remember that a top-right placement can still be acceptable if the latency and throughput are within expected bounds",
+              "background_color": "yellow",
+              "font_size": "14",
+              "text_align": "left",
+              "vertical_align": "top",
+              "show_tick": true,
+              "tick_pos": "50%",
+              "tick_edge": "top",
+              "has_padding": true
+            },
+            "layout": {
+              "x": 6,
+              "y": 4,
+              "width": 6,
+              "height": 1
+            }
+          },
+          {
+            "id": 5087230123283744,
+            "definition": {
+              "title": "Request Duration Distribution",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": true,
+              "type": "distribution",
+              "xaxis": {
+                "scale": "linear",
+                "min": "auto",
+                "max": "auto",
+                "include_zero": true
+              },
+              "yaxis": {
+                "scale": "linear",
+                "min": "auto",
+                "max": "auto",
+                "include_zero": true
+              },
+              "requests": [
+                {
+                  "request_type": "histogram",
+                  "query": {
+                    "data_source": "metrics",
+                    "name": "query1",
+                    "aggregator": "avg",
+                    "query": "avg:http.client.request.duration{service:$service.value, subgraph.name:*}"
+                  }
+                }
+              ]
+            },
+            "layout": {
+              "x": 0,
+              "y": 5,
+              "width": 6,
+              "height": 4
+            }
+          },
+          {
+            "id": 2538570288917588,
+            "definition": {
+              "type": "note",
+              "content": "**Recommended SLOs & Alerts:**\n\n-   Alert on P95 latency exceeding thresholds for critical subgraphs.\n-   Latency SLO (For High-Throughput): P95 Router → Subgraph latency should remain under 300ms\n-   Latency SLO (For Moderate-Throughput): Set threshold to (current P95 for the last week + 20%). This allows for natural variability while detecting regressions.\n",
+              "background_color": "white",
+              "font_size": "14",
+              "text_align": "left",
+              "vertical_align": "top",
+              "show_tick": false,
+              "tick_pos": "50%",
+              "tick_edge": "left",
+              "has_padding": true
+            },
+            "layout": {
+              "x": 6,
+              "y": 5,
+              "width": 6,
+              "height": 2
+            }
+          },
+          {
+            "id": 1275499059031764,
+            "definition": {
+              "type": "note",
+              "content": "This chart visualizes the distribution of subgraph request durations over time. It helps identify how long most requests take and highlights the presence of any outliers or tail latency issues.\n\n### What to Look For\n\n-   A tight cluster around low durations suggests fast, consistent subgraph responses.\n-   A long tail or spread to the right may indicate occasional slowness or outliers.\n-   Sudden shape changes over time can highlight new regressions, changes in traffic, or schema changes.",
+              "background_color": "yellow",
+              "font_size": "14",
+              "text_align": "left",
+              "vertical_align": "top",
+              "show_tick": true,
+              "tick_pos": "50%",
+              "tick_edge": "top",
+              "has_padding": true
+            },
+            "layout": {
+              "x": 0,
+              "y": 9,
+              "width": 6,
+              "height": 1
+            }
+          }
+        ]
+      },
+      "layout": {
+        "x": 0,
+        "y": 0,
+        "width": 12,
+        "height": 11,
+        "is_column_break": true
+      }
+    },
+    {
+      "id": 5499564723801628,
+      "definition": {
+        "title": "Top Most Queried Subgraphs: Request Duration Distributions",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "split_group",
+        "source_widget_definition": {
+          "title": "",
+          "title_size": "16",
+          "title_align": "left",
+          "type": "distribution",
+          "xaxis": {
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "yaxis": {
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "requests": [
+            {
+              "request_type": "histogram",
+              "query": {
+                "data_source": "metrics",
+                "name": "query1",
+                "query": "histogram:http.client.request.duration{$service, subgraph.name:*}"
+              }
+            }
+          ]
+        },
+        "split_config": {
+          "split_dimensions": [
+            {
+              "one_graph_per": "subgraph.name"
+            }
+          ],
+          "limit": 12,
+          "sort": {
+            "order": "desc",
+            "compute": {
+              "aggregation": "count",
+              "metric": "http.client.request.duration"
+            }
+          }
+        },
+        "size": "xs",
+        "has_uniform_y_axes": true
+      },
+      "layout": {
+        "x": 0,
+        "y": 11,
+        "width": 12,
+        "height": 5
+      }
+    }
+  ],
+  "template_variables": [
+    {
+      "name": "service",
+      "prefix": "service",
+      "available_values": [],
+      "default": "*"
+    }
+  ],
+  "layout_type": "ordered",
+  "notify_list": [],
+  "reflow_type": "fixed",
+  "tags": [
+    "team:runtime-readiness"
+  ]
+}


### PR DESCRIPTION
[RR-66](https://apollographql.atlassian.net/browse/RR-66)


[Dashboard](https://app.datadoghq.com/dashboard/68y-wn4-f3e?fromUser=false&refresh_mode=sliding&tpl_var_service%5B0%5D=observability-workshop-router&tpl_var_service%5B1%5D=router&from_ts=1749026759654&to_ts=1749631559654&live=true)
A chart for `http.client.request.body.size` was not able to be created because it is missing from data. here is the ticket for the router team to investigate [ROUTER-1317](https://apollographql.atlassian.net/browse/ROUTER-1317)

Personally I think we could use a chart showing an error rate per subgraph which would require a sum of the the graphql errors and the non 2xx requests. I attempted one but there wasn't any data for `graphql.errors` even though it is configured in the router.yml. If you also think this would be worth adding then let me know in the comments and I'll create a card for it. 




[RR-66]: https://apollographql.atlassian.net/browse/RR-66?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ROUTER-1317]: https://apollographql.atlassian.net/browse/ROUTER-1317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ