### PR TITLE
RR-66 Add env and version filters

### DIFF
--- a/datadog/request-metrics.json
+++ b/datadog/request-metrics.json
@@ -5,7 +5,7 @@
     {
       "id": 8946993247458357,
       "definition": {
-        "title": "Request Traffic & Health (Router)",
+        "title": "Request Traffic & Health: Client -> Router",
         "background_color": "vivid_blue",
         "show_title": true,
         "type": "group",
@@ -34,7 +34,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "count:http.server.request.duration{$service} by {http.response.status_code}.as_count()"
+                      "query": "count:http.server.request.duration{$service, $env ,$version} by {http.response.status_code}.as_count()"
                     }
                   ],
                   "formulas": [
@@ -79,7 +79,6 @@
                 "value",
                 "sum"
               ],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -88,7 +87,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "count:http.server.request.duration{$service}.as_count()"
+                      "query": "count:http.server.request.duration{$service, $env ,$version}.as_count()"
                     }
                   ],
                   "formulas": [
@@ -168,7 +167,7 @@
     {
       "id": 3840969086320674,
       "definition": {
-        "title": " Request Characteristics (Router)",
+        "title": " Request Characteristics: Client -> Router",
         "background_color": "vivid_blue",
         "show_title": true,
         "type": "group",
@@ -197,34 +196,34 @@
                     {
                       "name": "query1",
                       "data_source": "metrics",
-                      "query": "max:http.server.request.body.size{$service}"
+                      "query": "max:http.server.request.body.size{$service, $env ,$version}"
                     },
                     {
                       "name": "query2",
                       "data_source": "metrics",
-                      "query": "p99:http.server.request.body.size{$service}"
+                      "query": "p99:http.server.request.body.size{$service, $env ,$version}"
                     }
                   ],
                   "formulas": [
                     {
                       "alias": "max",
-                      "formula": "query1",
                       "number_format": {
                         "unit": {
                           "type": "canonical_unit",
                           "unit_name": "byte_in_decimal_bytes_family"
                         }
-                      }
+                      },
+                      "formula": "query1"
                     },
                     {
                       "alias": "p99",
-                      "formula": "query2",
                       "number_format": {
                         "unit": {
                           "type": "canonical_unit",
                           "unit_name": "byte_in_decimal_bytes_family"
                         }
-                      }
+                      },
+                      "formula": "query2"
                     }
                   ],
                   "style": {
@@ -281,7 +280,7 @@
     {
       "id": 2547398354023131,
       "definition": {
-        "title": "Request Performance & Latency (Router)",
+        "title": "Request Performance & Latency: Cient -> Router",
         "background_color": "vivid_blue",
         "show_title": true,
         "type": "group",
@@ -335,7 +334,7 @@
                     "data_source": "metrics",
                     "name": "query1",
                     "aggregator": "avg",
-                    "query": "avg:http.server.request.duration{service:$service.value}"
+                    "query": "avg:http.server.request.duration{$service, $env ,$version}"
                   }
                 }
               ]
@@ -417,27 +416,27 @@
                     {
                       "name": "query2",
                       "data_source": "metrics",
-                      "query": "p99:http.server.request.duration{$service}"
+                      "query": "p99:http.server.request.duration{$service, $env ,$version}"
                     },
                     {
                       "name": "query3",
                       "data_source": "metrics",
-                      "query": "p95:http.server.request.duration{$service}"
+                      "query": "p95:http.server.request.duration{$service, $env ,$version}"
                     },
                     {
                       "name": "query4",
                       "data_source": "metrics",
-                      "query": "p90:http.server.request.duration{$service}"
+                      "query": "p90:http.server.request.duration{$service, $env ,$version}"
                     },
                     {
                       "name": "query5",
                       "data_source": "metrics",
-                      "query": "min:http.server.request.duration{$service}"
+                      "query": "min:http.server.request.duration{$service, $env ,$version}"
                     },
                     {
                       "name": "query6",
                       "data_source": "metrics",
-                      "query": "max:http.server.request.duration{$service}"
+                      "query": "max:http.server.request.duration{$service, $env ,$version}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -518,7 +517,6 @@
                 "value",
                 "sum"
               ],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -527,12 +525,12 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "p95:http.server.request.duration{$service}"
+                      "query": "p95:http.server.request.duration{$service, $env ,$version}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "p95:http.client.request.duration{$service , subgraph.name:*}"
+                      "query": "p95:http.client.request.duration{$service, $env ,$version ,subgraph.name:*}"
                     }
                   ],
                   "formulas": [
@@ -594,6 +592,18 @@
     {
       "name": "service",
       "prefix": "service",
+      "available_values": [],
+      "default": "*"
+    },
+    {
+      "name": "env",
+      "prefix": "env",
+      "available_values": [],
+      "default": "*"
+    },
+    {
+      "name": "version",
+      "prefix": "version",
       "available_values": [],
       "default": "*"
     }

--- a/datadog/subgraph-request-metrics.json
+++ b/datadog/subgraph-request-metrics.json
@@ -26,6 +26,7 @@
                 "value",
                 "sum"
               ],
+              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -38,7 +39,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "count:http.client.request.duration{$service} by {subgraph.name,http.response.status_code}.as_count()"
+                      "query": "count:http.client.request.duration{$service, $env ,$version} by {subgraph.name,http.response.status_code}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -74,6 +75,7 @@
                 "value",
                 "sum"
               ],
+              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -82,7 +84,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "count:http.client.request.duration{$service} by {subgraph.name}.as_count()"
+                      "query": "count:http.client.request.duration{$service, $env ,$version} by {subgraph.name}.as_count()"
                     }
                   ],
                   "formulas": [
@@ -165,6 +167,7 @@
                 "value",
                 "sum"
               ],
+              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -176,7 +179,7 @@
                   ],
                   "queries": [
                     {
-                      "query": "count:http.client.request.duration{subgraph.name:*,!http.response.status_code:2*,$service} by {subgraph.name,http.response.status_code}.as_count()",
+                      "query": "count:http.client.request.duration{subgraph.name:*,!http.response.status_code:2* ,$service, $env ,$version} by {subgraph.name,http.response.status_code}.as_count()",
                       "data_source": "metrics",
                       "name": "query1"
                     }
@@ -298,26 +301,27 @@
                 "value",
                 "sum"
               ],
+              "time": {},
               "type": "timeseries",
               "requests": [
                 {
                   "formulas": [
                     {
                       "alias": "Sum",
-                      "formula": "query4",
                       "number_format": {
                         "unit": {
                           "type": "canonical_unit",
                           "unit_name": "byte_in_decimal_bytes_family"
                         }
-                      }
+                      },
+                      "formula": "query4"
                     }
                   ],
                   "queries": [
                     {
                       "name": "query4",
                       "data_source": "metrics",
-                      "query": "avg:http.client.response.body.size{$service} by {subgraph.name}.as_count()"
+                      "query": "avg:http.client.response.body.size{$service, $env ,$version} by {subgraph.name}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -392,6 +396,7 @@
                 "value",
                 "sum"
               ],
+              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -400,7 +405,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "p95:http.client.request.duration{$service} by {subgraph.name}"
+                      "query": "p95:http.client.request.duration{$service, $env ,$version} by {subgraph.name}"
                     }
                   ],
                   "formulas": [
@@ -445,13 +450,13 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "count:http.client.request.duration{$service} by {subgraph.name}.as_count()",
+                      "query": "count:http.client.request.duration{$service, $env ,$version} by {subgraph.name}.as_count()",
                       "aggregator": "sum"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "p95:http.client.request.duration{$service} by {subgraph.name}",
+                      "query": "p95:http.client.request.duration{$service, $env ,$version} by {subgraph.name}",
                       "aggregator": "percentile"
                     }
                   ],
@@ -541,6 +546,7 @@
               "title_size": "16",
               "title_align": "left",
               "show_legend": true,
+              "time": {},
               "type": "distribution",
               "xaxis": {
                 "scale": "linear",
@@ -561,7 +567,7 @@
                     "data_source": "metrics",
                     "name": "query1",
                     "aggregator": "avg",
-                    "query": "avg:http.client.request.duration{service:$service.value, subgraph.name:*}"
+                    "query": "avg:http.client.request.duration{subgraph.name:* ,$service, $env ,$version}"
                   }
                 }
               ]
@@ -655,7 +661,8 @@
               "query": {
                 "data_source": "metrics",
                 "name": "query1",
-                "query": "histogram:http.client.request.duration{$service, subgraph.name:*}"
+                "aggregator": "avg",
+                "query": "avg:http.client.request.duration{subgraph.name:* ,$service, $env ,$version}"
               }
             }
           ]
@@ -690,6 +697,18 @@
     {
       "name": "service",
       "prefix": "service",
+      "available_values": [],
+      "default": "*"
+    },
+    {
+      "name": "env",
+      "prefix": "env",
+      "available_values": [],
+      "default": "*"
+    },
+    {
+      "name": "version",
+      "prefix": "version",
       "available_values": [],
       "default": "*"
     }


### PR DESCRIPTION
[RR-96](https://apollographql.atlassian.net/browse/RR-96)

added the env and version filters. The reason why the data points were missing was a combination of metric configuration in datadog and the way they were configured in the router.yml 

I added env and version filters to 
[incoming http requests section](https://app.datadoghq.com/dashboard/rqe-it2-pcw?fromUser=false&refresh_mode=sliding&tpl_var_env%5B0%5D=local&tpl_var_service%5B0%5D=observability-workshop-router&tpl_var_version%5B0%5D=2.2.1&from_ts=1749840904658&to_ts=1749842704658&live=true)

and 

[subgraph http requests](https://app.datadoghq.com/dashboard/68y-wn4-f3e?fromUser=true&refresh_mode=sliding&tpl_var_service%5B0%5D=observability-workshop-router&tpl_var_service%5B1%5D=router&tpl_var_version%5B0%5D=2.3.0&from_ts=1749837328264&to_ts=1749840928264&live=true)

There's also some small changes such as naming. 

[RR-96]: https://apollographql.atlassian.net/browse/RR-96?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ