### PR TITLE
Implement part of the dashboard style guide

### DIFF
--- a/datadog/graphos-template.json
+++ b/datadog/graphos-template.json
@@ -64,7 +64,7 @@
                     }
                   ],
                   "style": {
-                    "palette": "semantic",
+                    "palette": "dog_classic",
                     "order_by": "values",
                     "line_type": "solid",
                     "line_width": "normal"
@@ -676,7 +676,7 @@
                   ],
                   "response_format": "timeseries",
                   "style": {
-                    "palette": "semantic",
+                    "palette": "dog_classic",
                     "order_by": "values",
                     "line_type": "solid",
                     "line_width": "normal"
@@ -725,7 +725,7 @@
                     }
                   ],
                   "style": {
-                    "palette": "semantic",
+                    "palette": "dog_classic",
                     "order_by": "values",
                     "line_type": "solid",
                     "line_width": "normal"
@@ -816,7 +816,7 @@
                   ],
                   "response_format": "timeseries",
                   "style": {
-                    "palette": "semantic",
+                    "palette": "dog_classic",
                     "line_type": "dotted",
                     "line_width": "normal"
                   },
@@ -1003,7 +1003,7 @@
                   ],
                   "response_format": "timeseries",
                   "style": {
-                    "palette": "semantic",
+                    "palette": "dog_classic",
                     "line_type": "solid",
                     "line_width": "normal"
                   },
@@ -1118,7 +1118,7 @@
                     }
                   ],
                   "style": {
-                    "palette": "semantic",
+                    "palette": "dog_classic",
                     "order_by": "values",
                     "line_type": "solid",
                     "line_width": "normal"
@@ -3142,7 +3142,7 @@
                     {
                       "number_format": {},
                       "style": {
-                        "palette": "classic",
+                        "palette": "dog_classic",
                         "palette_index": 4
                       },
                       "alias": "avg stolen",
@@ -3151,7 +3151,7 @@
                     {
                       "number_format": {},
                       "style": {
-                        "palette": "classic",
+                        "palette": "dog_classic",
                         "palette_index": 5
                       },
                       "alias": "avg iowait",
@@ -3160,7 +3160,7 @@
                     {
                       "number_format": {},
                       "style": {
-                        "palette": "classic",
+                        "palette": "dog_classic",
                         "palette_index": 1
                       },
                       "alias": "avg system",
@@ -3169,7 +3169,7 @@
                     {
                       "number_format": {},
                       "style": {
-                        "palette": "classic",
+                        "palette": "dog_classic",
                         "palette_index": 2
                       },
                       "alias": "avg user",
@@ -3178,7 +3178,7 @@
                     {
                       "number_format": {},
                       "style": {
-                        "palette": "classic",
+                        "palette": "dog_classic",
                         "palette_index": 0
                       },
                       "alias": "avg idle",
@@ -3250,7 +3250,7 @@
                     {
                       "number_format": {},
                       "style": {
-                        "palette": "classic",
+                        "palette": "dog_classic",
                         "palette_index": 1
                       },
                       "alias": "avg cpu",
@@ -3259,7 +3259,7 @@
                     {
                       "number_format": {},
                       "style": {
-                        "palette": "classic",
+                        "palette": "dog_classic",
                         "palette_index": 1
                       },
                       "alias": "max cpu",


### PR DESCRIPTION
This PR implements portions of [APM Dashboard Design Guide](https://apollographql.atlassian.net/wiki/spaces/RUNTIMEREADINESS/pages/1729986631/APM+Dashboard+Design+Guide):

- **Replace -> with →**
- **Make group header backgrounds gray**
- **Top-align note text**
- **Make note backgrounds gray**
- **Decrease widget note font size to 12**
- **Make all widget notes 2 squares tall**
- **Resize and reorder widgets**
- **Make widgets use 'classic' color scheme**

Because these changes make for big diffs, I'd like to merge what I have so far and continue with this work tomorrow. 

You can view the current state of the dashboard after these changes here (for now): https://app.datadoghq.com/dashboard/7pt-sp3-sk2?fromUser=false&refresh_mode=sliding&from_ts=1754266950881&to_ts=1754353350881&live=true

https://apollographql.atlassian.net/browse/RR-244
