### PR TITLE
Document dashboard set up and how to configure router telemetry instrumentation.

### DIFF
--- a/datadog/README.md
+++ b/datadog/README.md
@@ -53,7 +53,7 @@ telemetry:
           otel.name: router
           operation.name: "router"
           resource.name:
-            request_method: true # or replace with <operation_name : string> to see the operation name of the graphql request in the APM UI but be weary of trace metrics. This could result in high cardinality metrics on the resource_name attribute. ex: avg:trace.router{*} by {resource_name}
+            request_method: true # or replace with <operation_name : string> to see the operation name of the graphql request in the APM UI but be wary of trace metrics. This could result in high cardinality metrics on the resource_name attribute. ex: avg:trace.router{*} by {resource_name}
 
       supergraph: # Apollo specific attribute options: https://www.apollographql.com/docs/graphos/routing/observability/telemetry/instrumentation/standard-attributes#supergraph
         attributes:


### PR DESCRIPTION
Adds a ready-to-import Router v2 telemetry config that users can use to configure their router to emit metrics and traces that the dashboard depends on. This is not an entire router configuration but is just the telemetry instrumentation section. Users will still need to have their own telemetry exporters section for the telemetry to get to datadog. My target audience for this documentation is currently limited to users who are already using router v2, and already have data in datadog.  Future work will expand to users who are connecting their router to datadog for the first time.
  
Note: There wasn't any instructions on how to import the dashboard into datadog so I added that as well. 

If you have feedback or requested changes, feel free to push directly to this branch.