### PR TITLE
Add GraphQL Errors by Subgraph widget

### DIFF
--- a/datadog/graphos-template.json
+++ b/datadog/graphos-template.json
@@ -1125,11 +1125,11 @@
           {
             "id": 8695944198127783,
             "definition": {
-              "title": "P95 Latency",
+              "title": "P95 Latency by Subgraph",
               "title_size": "16",
               "title_align": "left",
-              "show_legend": false,
-              "legend_layout": "auto",
+              "show_legend": true,
+              "legend_layout": "vertical",
               "legend_columns": [
                 "avg",
                 "min",
@@ -1193,34 +1193,44 @@
             }
           },
           {
-            "id": 7867354547639656,
+            "id": 2531855480044862,
             "definition": {
-              "title": "Request Duration Distribution",
+              "title": "GraphQL Errors by Subgraph",
               "title_size": "16",
               "title_align": "left",
               "show_legend": true,
-              "type": "distribution",
-              "xaxis": {
-                "scale": "linear",
-                "min": "auto",
-                "max": "auto",
-                "include_zero": true
-              },
-              "yaxis": {
-                "scale": "linear",
-                "min": "auto",
-                "max": "auto",
-                "include_zero": true
-              },
+              "legend_layout": "vertical",
+              "legend_columns": [
+                "avg",
+                "min",
+                "max",
+                "value",
+                "sum"
+              ],
+              "type": "timeseries",
               "requests": [
                 {
-                  "request_type": "histogram",
-                  "query": {
-                    "data_source": "metrics",
-                    "name": "query1",
-                    "aggregator": "avg",
-                    "query": "avg:http.client.request.duration{subgraph.name:*,$service,$env,$version}"
-                  }
+                  "formulas": [
+                    {
+                      "alias": "GraphQL errors",
+                      "formula": "query1"
+                    }
+                  ],
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "sum:http.client.request.duration{$service,$env,$version , !connector.source.name:*, graphql.errors:true} by {subgraph.name}.as_count()"
+                    }
+                  ],
+                  "response_format": "timeseries",
+                  "style": {
+                    "palette": "dog_classic",
+                    "order_by": "values",
+                    "line_type": "solid",
+                    "line_width": "normal"
+                  },
+                  "display_type": "bars"
                 }
               ]
             },
@@ -1253,10 +1263,10 @@
             }
           },
           {
-            "id": 3281217598321122,
+            "id": 7416303106009039,
             "definition": {
               "type": "note",
-              "content": "This chart shows the distribution of backend request durations over time. It helps identify how long most requests take and highlights the presence of any outliers or tail latency issues.\n\n**What to look for**\n\n- A tight cluster around low durations suggests fast, consistent subgraph responses.\n- A long tail or spread to the right may indicate occasional slowness or outliers.\n- Sudden shape changes over time can highlight new regressions, changes in traffic, or schema changes.",
+              "content": "This chart shows GraphQL errors by subgraph\n\n**What to look for**\n\n- Sudden spikes in errors for a specific subgraph\n\n**Why it matters**\n\n- GraphQL errors are surfaced in the response body in the `errors` array. If a request encounters a GraphQL error, the overall response still returns a `200 OK`. Looking at errors by subgraph can help highlight response degradation when individual subgraphs encounter elevated error rates.",
               "background_color": "gray",
               "font_size": "12",
               "text_align": "left",
@@ -1568,6 +1578,66 @@
               "width": 6,
               "height": 2
             }
+          },
+          {
+            "id": 7867354547639656,
+            "definition": {
+              "title": "Request Duration Distribution",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": true,
+              "type": "distribution",
+              "xaxis": {
+                "scale": "linear",
+                "min": "auto",
+                "max": "auto",
+                "include_zero": true
+              },
+              "yaxis": {
+                "scale": "linear",
+                "min": "auto",
+                "max": "auto",
+                "include_zero": true
+              },
+              "requests": [
+                {
+                  "request_type": "histogram",
+                  "query": {
+                    "data_source": "metrics",
+                    "name": "query1",
+                    "aggregator": "avg",
+                    "query": "avg:http.client.request.duration{subgraph.name:*,$service,$env,$version}"
+                  }
+                }
+              ]
+            },
+            "layout": {
+              "x": 0,
+              "y": 18,
+              "width": 6,
+              "height": 4
+            }
+          },
+          {
+            "id": 3281217598321122,
+            "definition": {
+              "type": "note",
+              "content": "This chart shows the distribution of backend request durations over time. It helps identify how long most requests take and highlights the presence of any outliers or tail latency issues.\n\n**What to look for**\n\n- A tight cluster around low durations suggests fast, consistent subgraph responses.\n- A long tail or spread to the right may indicate occasional slowness or outliers.\n- Sudden shape changes over time can highlight new regressions, changes in traffic, or schema changes.",
+              "background_color": "gray",
+              "font_size": "12",
+              "text_align": "left",
+              "vertical_align": "top",
+              "show_tick": true,
+              "tick_pos": "50%",
+              "tick_edge": "top",
+              "has_padding": true
+            },
+            "layout": {
+              "x": 0,
+              "y": 22,
+              "width": 6,
+              "height": 2
+            }
           }
         ]
       },
@@ -1575,7 +1645,7 @@
         "x": 0,
         "y": 61,
         "width": 12,
-        "height": 19
+        "height": 25
       }
     },
     {
@@ -1634,7 +1704,7 @@
       },
       "layout": {
         "x": 0,
-        "y": 80,
+        "y": 86,
         "width": 12,
         "height": 5
       }
@@ -1695,7 +1765,7 @@
       },
       "layout": {
         "x": 0,
-        "y": 85,
+        "y": 91,
         "width": 12,
         "height": 3
       }
@@ -2047,7 +2117,7 @@
       },
       "layout": {
         "x": 0,
-        "y": 88,
+        "y": 94,
         "width": 12,
         "height": 8
       }
@@ -2601,7 +2671,7 @@
       },
       "layout": {
         "x": 0,
-        "y": 96,
+        "y": 102,
         "width": 12,
         "height": 24
       }
@@ -3196,7 +3266,7 @@
       },
       "layout": {
         "x": 0,
-        "y": 120,
+        "y": 126,
         "width": 12,
         "height": 15,
         "is_column_break": true
@@ -4119,7 +4189,7 @@
       },
       "layout": {
         "x": 0,
-        "y": 135,
+        "y": 141,
         "width": 12,
         "height": 11
       }
@@ -4379,7 +4449,7 @@
       },
       "layout": {
         "x": 0,
-        "y": 146,
+        "y": 152,
         "width": 12,
         "height": 15
       }
@@ -4591,7 +4661,7 @@
       },
       "layout": {
         "x": 0,
-        "y": 161,
+        "y": 167,
         "width": 12,
         "height": 8
       }
@@ -4865,7 +4935,7 @@
       },
       "layout": {
         "x": 0,
-        "y": 169,
+        "y": 175,
         "width": 12,
         "height": 6
       }

--- a/datadog/graphos-template.json
+++ b/datadog/graphos-template.json
@@ -878,6 +878,7 @@
                 "value",
                 "sum"
               ],
+              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -887,7 +888,7 @@
                       "name": "query1",
                       "data_source": "spans",
                       "search": {
-                        "query": "$service $env $version status:error"
+                        "query": "$service $env $version status:error operation_name:supergraph"
                       },
                       "indexes": [
                         "*"


### PR DESCRIPTION
This PR adds a new "GraphQL Errors by Subgraph" widget to the Request Performance & Latency: Router → Backend section of the dashboard template. This new widget uses the `graphql.errors:true` metric tag on the `http.client.request.duration` metric, which is not currently enabled for the parochial (in-house) router but is enabled for the observability-workshop-router. 

This PR also:
* Updates the name of the "P95 Latency" widget to "P95 Latency by Subgraph"
* Adds the full fidelity legend to the "P95 Latency by Subgraph" widget
* Rearranges widgets in the "Request Performance & Latency: Router → Backend" to ensure that the paired widgets remain side by side.

#### Screenshot of dashboard widgets after changes

<img width="1296" height="585" alt="Screenshot 2025-08-19 at 16 01 17" src="https://github.com/user-attachments/assets/3f28a0a1-7196-4837-b7c8-a660ef046520" />

https://apollographql.atlassian.net/browse/RR-284
