### PR TITLE
Filter subgraph operations from GraphQL Errors by Operation

### DIFF
--- a/datadog/graphos-template.json
+++ b/datadog/graphos-template.json
@@ -878,6 +878,7 @@
                 "value",
                 "sum"
               ],
+              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -887,7 +888,7 @@
                       "name": "query1",
                       "data_source": "spans",
                       "search": {
-                        "query": "$service $env $version status:error"
+                        "query": "$service $env $version status:error operation_name:supergraph"
                       },
                       "indexes": [
                         "*"


### PR DESCRIPTION
This PR adds the `operation_name:supergraph` filter to the "GraphQL Errors by Operation" in order to filter out subgraph (internal) operations. We've decided to filter out subgraph operations because we believe the subgraph level of granularity reduces the usefulness of this graph. Routers may not be configured to emit subgraph operation attributes, but if they are, this filter should correctly remove them.

Operation-level metrics have the potential to be expensive because unique operation names is potentially unbounded. To mitigate cost risk, we've made the decision to produce this graph using traces, instead. To verify that this trace filtering strategy produces the same results as a metric-driven approach, I temporarily created the metric version of this dashboard. Besides operation name casing and "N/A" values in the metric version, the graphs appear to be identical.

#### Side by side comparison
<img width="1275" height="342" alt="Screenshot 2025-08-19 at 16 29 44" src="https://github.com/user-attachments/assets/86420fb5-d9fb-41aa-a3a3-36f264ec1db8" />

#### Metric query
<img width="825" height="663" alt="Screenshot 2025-08-19 at 16 30 10" src="https://github.com/user-attachments/assets/e43a43a6-b0d1-413e-b0f7-56c2f1b2ea4f" />

#### Span query
<img width="825" height="660" alt="Screenshot 2025-08-19 at 16 30 41" src="https://github.com/user-attachments/assets/36ca190d-83d5-479c-8771-72df28c0f96d" />

https://apollographql.atlassian.net/browse/RR-284
