### PR TITLE
Move GraphQL Errors by Operation widget

### DIFF
--- a/datadog/graphos-template.json
+++ b/datadog/graphos-template.json
@@ -604,6 +604,96 @@
               "width": 6,
               "height": 2
             }
+          },
+          {
+            "id": 8599343953934762,
+            "definition": {
+              "title": "GraphQL Errors by Operation",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": true,
+              "legend_layout": "auto",
+              "legend_columns": [
+                "avg",
+                "min",
+                "max",
+                "value",
+                "sum"
+              ],
+              "type": "timeseries",
+              "requests": [
+                {
+                  "response_format": "timeseries",
+                  "queries": [
+                    {
+                      "name": "query1",
+                      "data_source": "spans",
+                      "search": {
+                        "query": "$service $env $version status:error operation_name:supergraph"
+                      },
+                      "indexes": [
+                        "*"
+                      ],
+                      "group_by": [
+                        {
+                          "facet": "@graphql.operation.name",
+                          "limit": 10,
+                          "sort": {
+                            "aggregation": "count",
+                            "order": "desc",
+                            "metric": "count"
+                          },
+                          "should_exclude_missing": true
+                        }
+                      ],
+                      "compute": {
+                        "aggregation": "count"
+                      },
+                      "storage": "hot"
+                    }
+                  ],
+                  "formulas": [
+                    {
+                      "formula": "query1"
+                    }
+                  ],
+                  "style": {
+                    "palette": "dog_classic",
+                    "order_by": "values",
+                    "line_type": "solid",
+                    "line_width": "normal"
+                  },
+                  "display_type": "bars"
+                }
+              ]
+            },
+            "layout": {
+              "x": 0,
+              "y": 9,
+              "width": 6,
+              "height": 4
+            }
+          },
+          {
+            "id": 2267185731841157,
+            "definition": {
+              "type": "note",
+              "content": "This chart focuses specifically on GraphQL errors from subgraphs — grouped by query operation name.\n\n**Why it matters**\n\n- These are the requests that reported back a 2xx response, but with errors within the actual GraphQL response.\n- These do not directly impact router performance, but can be an indicator of incorrect logic on your client or subgraph side.\n\n**Caveats**\n\n- This chart is populated via traces, not metrics, so the numbers will not necessarily be absolute.",
+              "background_color": "gray",
+              "font_size": "12",
+              "text_align": "left",
+              "vertical_align": "top",
+              "show_tick": true,
+              "tick_pos": "50%",
+              "tick_edge": "top",
+              "has_padding": true
+            },
+            "layout": {
+              "x": 0,
+              "y": 13,
+              "width": 6,
+              "height": 2
+            }
           }
         ]
       },
@@ -611,7 +701,7 @@
         "x": 0,
         "y": 26,
         "width": 12,
-        "height": 10
+        "height": 16
       }
     },
     {
@@ -864,76 +954,6 @@
             }
           },
           {
-            "id": 8599343953934762,
-            "definition": {
-              "title": "GraphQL Errors by Operation",
-              "title_size": "16",
-              "title_align": "left",
-              "show_legend": true,
-              "legend_layout": "auto",
-              "legend_columns": [
-                "avg",
-                "min",
-                "max",
-                "value",
-                "sum"
-              ],
-              "time": {},
-              "type": "timeseries",
-              "requests": [
-                {
-                  "response_format": "timeseries",
-                  "queries": [
-                    {
-                      "name": "query1",
-                      "data_source": "spans",
-                      "search": {
-                        "query": "$service $env $version status:error operation_name:supergraph"
-                      },
-                      "indexes": [
-                        "*"
-                      ],
-                      "group_by": [
-                        {
-                          "facet": "@graphql.operation.name",
-                          "limit": 10,
-                          "sort": {
-                            "aggregation": "count",
-                            "order": "desc",
-                            "metric": "count"
-                          },
-                          "should_exclude_missing": true
-                        }
-                      ],
-                      "compute": {
-                        "aggregation": "count"
-                      },
-                      "storage": "hot"
-                    }
-                  ],
-                  "formulas": [
-                    {
-                      "formula": "query1"
-                    }
-                  ],
-                  "style": {
-                    "palette": "dog_classic",
-                    "order_by": "values",
-                    "line_type": "solid",
-                    "line_width": "normal"
-                  },
-                  "display_type": "bars"
-                }
-              ]
-            },
-            "layout": {
-              "x": 6,
-              "y": 11,
-              "width": 6,
-              "height": 4
-            }
-          },
-          {
             "id": 5549413731697892,
             "definition": {
               "type": "note",
@@ -953,33 +973,12 @@
               "width": 6,
               "height": 2
             }
-          },
-          {
-            "id": 2267185731841157,
-            "definition": {
-              "type": "note",
-              "content": "This chart focuses specifically on GraphQL errors from subgraphs — grouped by query operation name.\n\n**Why it matters**\n\n- These are the requests that reported back a 2xx response, but with errors within the actual GraphQL response.\n- These do not directly impact router performance, but can be an indicator of incorrect logic on your client or subgraph side.\n\n**Caveats**\n\n- This chart is populated via traces, not metrics, so the numbers will not necessarily be absolute.",
-              "background_color": "gray",
-              "font_size": "12",
-              "text_align": "left",
-              "vertical_align": "top",
-              "show_tick": true,
-              "tick_pos": "50%",
-              "tick_edge": "top",
-              "has_padding": true
-            },
-            "layout": {
-              "x": 6,
-              "y": 15,
-              "width": 6,
-              "height": 2
-            }
           }
         ]
       },
       "layout": {
         "x": 0,
-        "y": 36,
+        "y": 42,
         "width": 12,
         "height": 18
       }
@@ -1088,7 +1087,7 @@
       },
       "layout": {
         "x": 0,
-        "y": 54,
+        "y": 60,
         "width": 12,
         "height": 7
       }
@@ -1644,7 +1643,7 @@
       },
       "layout": {
         "x": 0,
-        "y": 61,
+        "y": 67,
         "width": 12,
         "height": 25
       }
@@ -1705,7 +1704,7 @@
       },
       "layout": {
         "x": 0,
-        "y": 86,
+        "y": 92,
         "width": 12,
         "height": 5
       }
@@ -1766,7 +1765,7 @@
       },
       "layout": {
         "x": 0,
-        "y": 91,
+        "y": 97,
         "width": 12,
         "height": 3
       }
@@ -2118,7 +2117,7 @@
       },
       "layout": {
         "x": 0,
-        "y": 94,
+        "y": 100,
         "width": 12,
         "height": 8
       }
@@ -2672,7 +2671,7 @@
       },
       "layout": {
         "x": 0,
-        "y": 102,
+        "y": 108,
         "width": 12,
         "height": 24
       }
@@ -3267,7 +3266,7 @@
       },
       "layout": {
         "x": 0,
-        "y": 126,
+        "y": 0,
         "width": 12,
         "height": 15,
         "is_column_break": true
@@ -4190,7 +4189,7 @@
       },
       "layout": {
         "x": 0,
-        "y": 141,
+        "y": 15,
         "width": 12,
         "height": 11
       }
@@ -4450,7 +4449,7 @@
       },
       "layout": {
         "x": 0,
-        "y": 152,
+        "y": 26,
         "width": 12,
         "height": 15
       }
@@ -4662,7 +4661,7 @@
       },
       "layout": {
         "x": 0,
-        "y": 167,
+        "y": 41,
         "width": 12,
         "height": 8
       }
@@ -4936,7 +4935,7 @@
       },
       "layout": {
         "x": 0,
-        "y": 175,
+        "y": 49,
         "width": 12,
         "height": 6
       }


### PR DESCRIPTION
This PR moves the GraphQL Errors by Operation widget from "Request Traffic & Health: Router → Backend" to the "Request Performance & Latency: Client → Router" section of the dashboard.

#### After
<img width="693" height="826" alt="Screenshot 2025-08-20 at 12 21 24" src="https://github.com/user-attachments/assets/ac8d04a3-6da1-4692-bf75-0b754b3031ec" />



This work is part of https://apollographql.atlassian.net/browse/RR-284