### PR TITLE
Move GraphQL Errors by Operation widget

### DIFF
--- a/datadog/graphos-template.json
+++ b/datadog/graphos-template.json
@@ -236,6 +236,75 @@
             }
           },
           {
+            "id": 8599343953934762,
+            "definition": {
+              "title": "GraphQL Errors by Operation",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": true,
+              "legend_layout": "auto",
+              "legend_columns": [
+                "avg",
+                "min",
+                "max",
+                "value",
+                "sum"
+              ],
+              "type": "timeseries",
+              "requests": [
+                {
+                  "response_format": "timeseries",
+                  "queries": [
+                    {
+                      "name": "query1",
+                      "data_source": "spans",
+                      "search": {
+                        "query": "$service $env $version status:error operation_name:supergraph"
+                      },
+                      "indexes": [
+                        "*"
+                      ],
+                      "group_by": [
+                        {
+                          "facet": "@graphql.operation.name",
+                          "limit": 10,
+                          "sort": {
+                            "aggregation": "count",
+                            "order": "desc",
+                            "metric": "count"
+                          },
+                          "should_exclude_missing": true
+                        }
+                      ],
+                      "compute": {
+                        "aggregation": "count"
+                      },
+                      "storage": "hot"
+                    }
+                  ],
+                  "formulas": [
+                    {
+                      "formula": "query1"
+                    }
+                  ],
+                  "style": {
+                    "palette": "dog_classic",
+                    "order_by": "values",
+                    "line_type": "solid",
+                    "line_width": "normal"
+                  },
+                  "display_type": "bars"
+                }
+              ]
+            },
+            "layout": {
+              "x": 6,
+              "y": 12,
+              "width": 6,
+              "height": 4
+            }
+          },
+          {
             "id": 6132914662720110,
             "definition": {
               "type": "note",
@@ -251,6 +320,27 @@
             },
             "layout": {
               "x": 0,
+              "y": 16,
+              "width": 6,
+              "height": 2
+            }
+          },
+          {
+            "id": 2267185731841157,
+            "definition": {
+              "type": "note",
+              "content": "This chart focuses specifically on GraphQL errors from subgraphs — grouped by query operation name.\n\n**Why it matters**\n\n- These are the requests that reported back a 2xx response, but with errors within the actual GraphQL response.\n- These do not directly impact router performance, but can be an indicator of incorrect logic on your client or subgraph side.\n\n**Caveats**\n\n- This chart is populated via traces, not metrics, so the numbers will not necessarily be absolute.",
+              "background_color": "gray",
+              "font_size": "12",
+              "text_align": "left",
+              "vertical_align": "top",
+              "show_tick": true,
+              "tick_pos": "50%",
+              "tick_edge": "top",
+              "has_padding": true
+            },
+            "layout": {
+              "x": 6,
               "y": 16,
               "width": 6,
               "height": 2
@@ -864,76 +954,6 @@
             }
           },
           {
-            "id": 8599343953934762,
-            "definition": {
-              "title": "GraphQL Errors by Operation",
-              "title_size": "16",
-              "title_align": "left",
-              "show_legend": true,
-              "legend_layout": "auto",
-              "legend_columns": [
-                "avg",
-                "min",
-                "max",
-                "value",
-                "sum"
-              ],
-              "time": {},
-              "type": "timeseries",
-              "requests": [
-                {
-                  "response_format": "timeseries",
-                  "queries": [
-                    {
-                      "name": "query1",
-                      "data_source": "spans",
-                      "search": {
-                        "query": "$service $env $version status:error operation_name:supergraph"
-                      },
-                      "indexes": [
-                        "*"
-                      ],
-                      "group_by": [
-                        {
-                          "facet": "@graphql.operation.name",
-                          "limit": 10,
-                          "sort": {
-                            "aggregation": "count",
-                            "order": "desc",
-                            "metric": "count"
-                          },
-                          "should_exclude_missing": true
-                        }
-                      ],
-                      "compute": {
-                        "aggregation": "count"
-                      },
-                      "storage": "hot"
-                    }
-                  ],
-                  "formulas": [
-                    {
-                      "formula": "query1"
-                    }
-                  ],
-                  "style": {
-                    "palette": "dog_classic",
-                    "order_by": "values",
-                    "line_type": "solid",
-                    "line_width": "normal"
-                  },
-                  "display_type": "bars"
-                }
-              ]
-            },
-            "layout": {
-              "x": 6,
-              "y": 11,
-              "width": 6,
-              "height": 4
-            }
-          },
-          {
             "id": 5549413731697892,
             "definition": {
               "type": "note",
@@ -949,27 +969,6 @@
             },
             "layout": {
               "x": 0,
-              "y": 15,
-              "width": 6,
-              "height": 2
-            }
-          },
-          {
-            "id": 2267185731841157,
-            "definition": {
-              "type": "note",
-              "content": "This chart focuses specifically on GraphQL errors from subgraphs — grouped by query operation name.\n\n**Why it matters**\n\n- These are the requests that reported back a 2xx response, but with errors within the actual GraphQL response.\n- These do not directly impact router performance, but can be an indicator of incorrect logic on your client or subgraph side.\n\n**Caveats**\n\n- This chart is populated via traces, not metrics, so the numbers will not necessarily be absolute.",
-              "background_color": "gray",
-              "font_size": "12",
-              "text_align": "left",
-              "vertical_align": "top",
-              "show_tick": true,
-              "tick_pos": "50%",
-              "tick_edge": "top",
-              "has_padding": true
-            },
-            "layout": {
-              "x": 6,
               "y": 15,
               "width": 6,
               "height": 2


### PR DESCRIPTION
This PR moves the GraphQL Errors by Operation widget from "Request Traffic & Health: Router → Backend" to the "Request Traffic & Health: Client → Router" section of the dashboard.

#### After
<img width="685" height="795" alt="Screenshot 2025-08-20 at 12 57 44" src="https://github.com/user-attachments/assets/c0bbb1f3-67a5-4217-aa01-4b49bf1296b8" />

This work is part of https://apollographql.atlassian.net/browse/RR-284