### PR TITLE
Fix upload dashboard script to retain the team identifier

### DIFF
--- a/datadog/utils/destructive_upload_dashboards.sh
+++ b/datadog/utils/destructive_upload_dashboards.sh
@@ -77,7 +77,7 @@ upload_dashboard() {
     fi
 
     local json_payload
-    json_payload=$(cat "$filename")
+    json_payload=$(cat "$filename" | jq '. += {"tags": ["team:runtime-readiness"]}')
 
     local http_code
     local response


### PR DESCRIPTION
This PR updates the `destructive_upload_dashboards.sh` script to retain team ownership of the dashboard during destructive uploads.