### PR TITLE
Exclude patch versions on dependencies to reduce renovate spam

### DIFF
--- a/.config/mise/mise.toml
+++ b/.config/mise/mise.toml
@@ -17,8 +17,8 @@ run = "dprint check"
 run = "typos"
 
 [tools]
-"cargo:dprint" = "0.50.0"
-"cargo:typos-cli" = "1.34.0"
+"cargo:dprint" = "0.50"
+"cargo:typos-cli" = "1.36"
 
 [env]
 _.file = '../../.env'

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,19 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
-    - uses: crate-ci/typos@v1.36.0
+    - uses: crate-ci/typos@v1
 
   lint-markdown:
     name: Lint Markdown files with dprint
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
-      # The action takes too long to build if we install all the tools in the repo
-      # This deletes the full mise.toml and instead installs dprint only
-    - run: rm -f .config/mise/mise.toml
-    - uses: jdx/mise-action@v3
-      with:
-        mise_toml: |
-          [tools]
-          dprint = "0.48.0"
-    - run: dprint check
+    - uses: dprint/check@v2.3


### PR DESCRIPTION
Since this repository neither contains private code nor do our actions run with secrets, it is low risk to not have to manually approve a renovate PR for every patch version. I also switched to an official dprint action instead of using the mise action, as renovate was not seeing that custom in-line config when updating and I don't see a particular reason not to use the official action instead.