### PR TITLE
Add fuzzy relative overhead chart

### DIFF
--- a/datadog/graphos-template.json
+++ b/datadog/graphos-template.json
@@ -45,7 +45,6 @@
                 "min",
                 "max"
               ],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -4629,6 +4628,100 @@
               "width": 6,
               "height": 2
             }
+          },
+          {
+            "id": 1270431771452126,
+            "definition": {
+              "title": "Router Relative Overhead",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": false,
+              "legend_layout": "auto",
+              "legend_columns": [
+                "avg",
+                "min",
+                "max",
+                "value",
+                "sum"
+              ],
+              "type": "timeseries",
+              "requests": [
+                {
+                  "response_format": "timeseries",
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query6",
+                      "query": "avg:http.server.request.duration{$service,$env}"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "query2",
+                      "query": "avg:apollo.router.compute_jobs.duration{$service,$env}"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "query5",
+                      "query": "avg:apollo.router.operations.coprocessor.duration{$service,$env}"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "query4",
+                      "query": "avg:http.client.request.duration{$service,$env}"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "query3",
+                      "query": "count:http.server.request.duration{$service,$env}.as_rate()"
+                    }
+                  ],
+                  "formulas": [
+                    {
+                      "alias": "health score",
+                      "formula": "((query6 - query2 - query5 - query4) * pow(10, 5)) / query3"
+                    }
+                  ],
+                  "style": {
+                    "palette": "dog_classic",
+                    "order_by": "tags",
+                    "line_type": "solid",
+                    "line_width": "normal"
+                  },
+                  "display_type": "line"
+                }
+              ],
+              "yaxis": {
+                "include_zero": true,
+                "scale": "linear"
+              }
+            },
+            "layout": {
+              "x": 0,
+              "y": 7,
+              "width": 6,
+              "height": 4
+            }
+          },
+          {
+            "id": 3032109276671033,
+            "definition": {
+              "type": "note",
+              "content": "This graph measures the average delta between your runtime's request duration and the duration spent in compute jobs, coprocessors, and subgraph requests, normalized against your incoming request rate. This is a fuzzy metric intended to provide a birds-eye view of your runtime's overall performance health that can identify trends and potential regressions in any one of the above components.\n\nThe exponential function in this chart needs to be manually configured to provide a useful numeric value based on your overall request rate. Ideally you should set the exponent such that the metric produces a value with at least one whole number of precision.\n\nChanges in this metric should be considered only over large time windows (multiple weeks, at minimum), and treated as a suggestion to investigate other dependent metrics. Trends are not necessarily direct cause for concern if those measured values remain within acceptable bounds.",
+              "background_color": "gray",
+              "font_size": "12",
+              "text_align": "left",
+              "vertical_align": "center",
+              "show_tick": true,
+              "tick_pos": "50%",
+              "tick_edge": "top",
+              "has_padding": true
+            },
+            "layout": {
+              "x": 0,
+              "y": 11,
+              "width": 6,
+              "height": 3
+            }
           }
         ]
       },
@@ -4636,7 +4729,7 @@
         "x": 0,
         "y": 168,
         "width": 12,
-        "height": 8
+        "height": 15
       }
     },
     {
@@ -4908,7 +5001,7 @@
       },
       "layout": {
         "x": 0,
-        "y": 176,
+        "y": 183,
         "width": 12,
         "height": 7
       }


### PR DESCRIPTION
This will go in tandem with a build-in measurement in the future, acting as a useful starting point for understanding the overall overhead health state of the router.
